### PR TITLE
Potential fix for code scanning alert no. 14: Insertion of sensitive information into log files

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/security/JwtAuthenticationProvider.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/security/JwtAuthenticationProvider.java
@@ -40,7 +40,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
 
     @Override
 	public Authentication authenticate(Authentication authentication) throws AuthenticationException {
-        logger.debug("Verifying key with secret '" + secret + "'");
+        logger.debug("Verifying key for JWT authentication");
         BearerTokenAuthenticationToken bearer = (BearerTokenAuthenticationToken) authentication;
 		try {
             SecretKeySpec secretKey = new SecretKeySpec(this.secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");


### PR DESCRIPTION
Potential fix for [https://github.com/feeds-devel/ghas-bootcamp-http/security/code-scanning/14](https://github.com/feeds-devel/ghas-bootcamp-http/security/code-scanning/14)

To fix the problem, remove the logging of the secret value from line 43. Instead, log a generic message that does not include the secret. For example, change the log statement to `"Verifying key for JWT authentication"` or similar. This ensures that no sensitive information is written to the log files, while still providing useful context for debugging. Only line 43 needs to be changed; no new imports or methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
